### PR TITLE
dev: add type-checking step during compilation using ForkTsCheckerWebpackPlugin

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -32,7 +32,7 @@ module.exports = {
         'class-methods-use-this': 'off',
         'import/no-unresolved': 'error',
     },
-    ignorePatterns: ['dist', '*.cjs', '*.config.js', '*setup.js'],
+    ignorePatterns: ['dist', '*.config.js', '*setup.js'],
     settings: {
         'import/parsers': {
             '@typescript-eslint/parser': ['.ts', '.js'],

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
   "private": true,
   "scripts": {
     "start": "webpack serve --mode=development",
-    "build": "tsc && webpack --mode=production",
-    "lint": "eslint . --ext .js,.ts",
+    "build": "webpack --mode=production",
+    "test": "jest",
+    "lint": "eslint src --ext .js,.ts",
     "format": "prettier --write src"
   },
   "browserslist": {
@@ -53,6 +54,7 @@
     "eslint-plugin-jest-dom": "^4.0.3",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-webpack-plugin": "^3.2.0",
+    "fork-ts-checker-webpack-plugin": "^7.2.14",
     "html-loader": "^4.2.0",
     "html-webpack-plugin": "^5.5.0",
     "jest": "^29.3.1",
@@ -64,8 +66,8 @@
     "prettier-eslint": "^15.0.1",
     "sass": "^1.56.2",
     "sass-loader": "^13.2.0",
-    "tailwindcss": "^3.2.4",
     "style-loader": "^3.3.1",
+    "tailwindcss": "^3.2.4",
     "typescript": "^4.9.4",
     "webpack": "^5.75.0",
     "webpack-cli": "^4.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,7 @@ specifiers:
   eslint-plugin-jest-dom: ^4.0.3
   eslint-plugin-prettier: ^4.2.1
   eslint-webpack-plugin: ^3.2.0
+  fork-ts-checker-webpack-plugin: ^7.2.14
   html-loader: ^4.2.0
   html-webpack-plugin: ^5.5.0
   jest: ^29.3.1
@@ -70,6 +71,7 @@ devDependencies:
   eslint-plugin-jest-dom: 4.0.3_eslint@8.29.0
   eslint-plugin-prettier: 4.2.1_5dgjrgoi64tgrv3zzn3walur3u
   eslint-webpack-plugin: 3.2.0_2godrbid5dlikbzpspaxqblgd4
+  fork-ts-checker-webpack-plugin: 7.2.14_3fkjkrd3audxnith3e7fo4fnxi
   html-loader: 4.2.0_webpack@5.75.0
   html-webpack-plugin: 5.5.0_webpack@5.75.0
   jest: 29.3.1_@types+node@18.11.15
@@ -5190,6 +5192,33 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /fork-ts-checker-webpack-plugin/7.2.14_3fkjkrd3audxnith3e7fo4fnxi:
+    resolution: {integrity: sha512-Tg2feh/n8k486KX0EbXVUfJj3j0xnnbKYTJw0fnIb2QdV0+lblOYZSal5ed9hARoWVwKeOC7sYE2EakSRLo5ZA==}
+    engines: {node: '>=12.13.0', yarn: '>=1.0.0'}
+    peerDependencies:
+      typescript: '>3.6.0'
+      vue-template-compiler: '*'
+      webpack: ^5.11.0
+    peerDependenciesMeta:
+      vue-template-compiler:
+        optional: true
+    dependencies:
+      '@babel/code-frame': 7.18.6
+      chalk: 4.1.2
+      chokidar: 3.5.3
+      cosmiconfig: 7.1.0
+      deepmerge: 4.2.2
+      fs-extra: 10.1.0
+      memfs: 3.4.12
+      minimatch: 3.1.2
+      node-abort-controller: 3.0.1
+      schema-utils: 3.1.1
+      semver: 7.3.8
+      tapable: 2.2.1
+      typescript: 4.9.4
+      webpack: 5.75.0_webpack-cli@4.10.0
+    dev: true
+
   /form-data/4.0.0:
     resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
     engines: {node: '>= 6'}
@@ -5218,6 +5247,15 @@ packages:
   /fresh/0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+    dev: true
+
+  /fs-extra/10.1.0:
+    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      graceful-fs: 4.2.10
+      jsonfile: 6.1.0
+      universalify: 2.0.0
     dev: true
 
   /fs-minipass/2.1.0:
@@ -6991,6 +7029,14 @@ packages:
     hasBin: true
     dev: true
 
+  /jsonfile/6.1.0:
+    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
+    dependencies:
+      universalify: 2.0.0
+    optionalDependencies:
+      graceful-fs: 4.2.10
+    dev: true
+
   /jsonparse/1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
@@ -7679,6 +7725,10 @@ packages:
     dependencies:
       lower-case: 2.0.2
       tslib: 2.4.1
+    dev: true
+
+  /node-abort-controller/3.0.1:
+    resolution: {integrity: sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw==}
     dev: true
 
   /node-fetch/2.6.7:
@@ -10014,6 +10064,11 @@ packages:
   /universalify/0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
+    dev: true
+
+  /universalify/2.0.0:
+    resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
+    engines: {node: '>= 10.0.0'}
     dev: true
 
   /unpipe/1.0.0:

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,8 +3,10 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { ESBuildMinifyPlugin } = require('esbuild-loader');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const ESLintPlugin = require('eslint-webpack-plugin');
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 const config = {
+  context: __dirname,
   entry: './src/index.ts',
   output: {
     path: path.join(__dirname, 'dist'),
@@ -40,6 +42,7 @@ const config = {
     new HtmlWebpackPlugin({
       template: 'index.html',
     }),
+    new ForkTsCheckerWebpackPlugin(),
   ],
   optimization: {
     minimizer: [
@@ -61,12 +64,15 @@ const config = {
       },
     },
   },
+  watchOptions: {
+    ignored: '**/node_modules',
+  },
 };
 
 module.exports = (env, argv) => {
   const isProduction = argv.mode === 'production';
 
-  const filename = (ext) => (isProduction ? `[name].[hash].${ext}` : `[name].${ext}`);
+  const filename = (ext) => (isProduction ? `[name].[fullhash].${ext}` : `[name].${ext}`);
 
   if (isProduction) {
     config.plugins.push(new MiniCssExtractPlugin({ filename: filename('css') }));


### PR DESCRIPTION
or after compilation when in dev mode

previously type-checking was done using tsc when using the build command and was skipped by webpack in development mode

add test command

change lint command to include src directory

remove tsc from build command